### PR TITLE
Increase Visibility (log errors). Fix Race condition.

### DIFF
--- a/doc_test.go
+++ b/doc_test.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/LIVEauctioneers/cony"
 	"github.com/LIVEauctioneers/amqp"
+	"github.com/LIVEauctioneers/cony"
 )
 
 func Example() {

--- a/examples/basic/producer/producer.go
+++ b/examples/basic/producer/producer.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/LIVEauctioneers/cony"
 	"github.com/LIVEauctioneers/amqp"
+	"github.com/LIVEauctioneers/cony"
 	"time"
 )
 

--- a/examples/email/producer/producer.go
+++ b/examples/email/producer/producer.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/LIVEauctioneers/cony"
 	"github.com/LIVEauctioneers/amqp"
+	"github.com/LIVEauctioneers/cony"
 )
 
 var port = flag.Int("port", 3000, "listening port")

--- a/examples/web/producer/producer.go
+++ b/examples/web/producer/producer.go
@@ -7,8 +7,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/LIVEauctioneers/cony"
 	"github.com/LIVEauctioneers/amqp"
+	"github.com/LIVEauctioneers/cony"
 )
 
 var port = flag.Int("port", 3000, "listening port")


### PR DESCRIPTION
The consumer.Cancel method wasn't sending on the `c.stop` channel. Instead it was closing both the `deliveries` and `stop` channel at the same time. Based on a test for that method, I am pretty sure that the reason for that is to prevent blocking, but it creates a race condition because `select` in `c.serve` will hit either option arbitrarily.
Also adds better logging around closing a consumer/channel.
